### PR TITLE
Add birth certificate issuance and verification smart contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/** linguist-vendored
+vitest.config.js linguist-vendored
+* text=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt
+
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# VeriBirth Smart Contract
+
+VeriBirth is a Clarity smart contract for secure, decentralized birth certificate issuance and verification on the Stacks blockchain.
+
+## Features
+
+- **Submit Birth Certificate:**  
+  Parents can submit birth certificate data, including child name, date of birth, gender, hospital, and a record hash.
+
+- **Hospital Verification:**  
+  Only the designated hospital can verify submitted certificates.
+
+- **Certificate Retrieval:**  
+  Anyone can read certificate details by ID.
+
+- **Auto-Incremented IDs:**  
+  Each certificate is assigned a unique, auto-incremented ID.
+
+## Contract Functions
+
+| Function                | Type         | Description                                                      |
+|-------------------------|--------------|------------------------------------------------------------------|
+| `submit-certificate`    | Public       | Submit a new birth certificate for approval.                     |
+| `verify-certificate`    | Public       | Hospital verifies a pending certificate.                         |
+| `get-certificate`       | Read-Only    | Retrieve certificate details by ID.                              |
+| `get-latest-id`         | Read-Only    | Get the latest certificate ID (next to be assigned).             |
+
+## Data Structures
+
+- **birth-certificates (map):**  
+  Stores certificate data keyed by certificate ID.
+
+- **pending-approvals (map):**  
+  Tracks certificates awaiting hospital verification.
+
+- **certificate-counter (variable):**  
+  Auto-incremented counter for certificate IDs.
+
+## Usage
+
+1. **Deploy the contract** to your Stacks testnet/mainnet environment.
+2. **Call `submit-certificate`** with required details to create a new certificate.
+3. **Hospital calls `verify-certificate`** to approve the certificate.
+4. **Use `get-certificate`** to view certificate data.
+
+## Error Codes
+
+- `u401` – Invalid child name length
+- `u402` – Invalid date of birth
+- `u403` – Invalid gender or unauthorized verification
+- `u404` – Invalid record hash or certificate not found
+- `u405` – Invalid hospital address or certificate ID
+
+## Requirements
+
+- [Clarity](https://docs.stacks.co/docs/clarity-language/)
+- Stacks blockchain environment

--- a/contracts/VeriBirth.clar
+++ b/contracts/VeriBirth.clar
@@ -1,0 +1,100 @@
+(define-data-var certificate-counter uint u0)
+
+(define-map birth-certificates
+  { certificate-id: uint } ;; auto-incremented ID
+  {
+    child-name: (string-utf8 50),
+    dob: uint, ;; date of birth in Unix timestamp
+    gender: (string-utf8 6),
+    parent: principal,
+    hospital: principal,
+    record-hash: (string-utf8 100),
+    is-verified: bool
+  })
+
+(define-map pending-approvals
+  { certificate-id: uint }
+  { hospital: principal })
+
+(define-public (submit-certificate 
+    (child-name (string-utf8 50)) 
+    (dob uint)
+    (gender (string-utf8 6))
+    (hospital principal)
+    (record-hash (string-utf8 100))
+  )
+  (let (
+        (current-id (var-get certificate-counter))
+      )
+    (begin
+      ;; Input validation
+      (asserts! (and 
+        (> (len child-name) u0) 
+        (< (len child-name) u50)
+      ) (err u401))
+      (asserts! (> dob u0) (err u402))
+      (asserts! (and 
+        (> (len gender) u0)
+        (< (len gender) u6)
+      ) (err u403))
+      (asserts! (and 
+        (> (len record-hash) u0)
+        (< (len record-hash) u100)
+      ) (err u404))
+      ;; Hospital validation - ensure it's not the zero address
+      (asserts! (not (is-eq hospital 'SP000000000000000000002Q6VF78)) (err u405))
+      (map-set birth-certificates
+        { certificate-id: current-id }
+        {
+          child-name: child-name,
+          dob: dob,
+          gender: gender,
+          parent: tx-sender,
+          hospital: hospital,
+          record-hash: record-hash,
+          is-verified: false
+        }
+      )
+      (map-set pending-approvals
+        { certificate-id: current-id }
+        { hospital: hospital }
+      )
+      (var-set certificate-counter (+ current-id u1))
+      (ok current-id)
+    )
+  )
+)
+
+(define-public (verify-certificate (certificate-id uint))
+  (begin
+    ;; Input validation
+    (asserts! (< certificate-id (var-get certificate-counter)) (err u405))
+    (let ((stored-hospital (unwrap! (map-get? pending-approvals { certificate-id: certificate-id }) (err u404))))
+      (if (is-eq (get hospital stored-hospital) tx-sender)
+        (begin
+          (map-set birth-certificates
+            { certificate-id: certificate-id }
+            (let ((existing (unwrap! (map-get? birth-certificates { certificate-id: certificate-id }) (err u404))))
+              (merge existing
+                {
+                  is-verified: true
+                }
+              )
+            )
+          )
+          (map-delete pending-approvals { certificate-id: certificate-id })
+          (ok true)
+        )
+        (err u403) ;; Unauthorized
+      )
+    )
+  )
+)
+
+(define-read-only (get-certificate (certificate-id uint))
+  (map-get? birth-certificates { certificate-id: certificate-id })
+)
+
+(define-read-only (get-latest-id)
+  (var-get certificate-counter)
+)


### PR DESCRIPTION
Request to add a Clarity smart contract for decentralized birth certificate management.
The contract enables users to submit birth certificates, allows hospitals to verify them, and provides read-only access to certificate data.
Includes input validation, auto-incremented certificate IDs, and error handling for common edge cases.
Looking for feedback on contract logic, security, and best practices for deployment on Stacks.